### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Ghostwill
+# Ghostwill
 
 ![ghostwill](http://file.is26.com/wp-image/2014/04/ghostwill.png)
 
@@ -10,7 +10,7 @@ for more info.Please contact [@foru17](http://twitter.com/foru17)
 
 
 
-####注意
+#### 注意
 
 若使用本主题，请修改`default.hbs`文件中的谷歌统计 Google Analytics 代码。
 
@@ -19,20 +19,20 @@ for more info.Please contact [@foru17](http://twitter.com/foru17)
 同时请修改`default.hbs`头部的`meta`相关信息。
 
 
-####关于Ghostwill
+#### 关于Ghostwill
 
 这个主题叫 [Ghostwill](https://github.com/foru17/ghostwill) ，中文名还没想好，暂时就叫「鬼才晓得」吧，已经放在 Github 开源了，请尽情撸，俗话说大家撸才是真的撸嘛，现在版本还是1.0.0。
 
-##几个特性
+## 几个特性
 
-###1.响应式
+### 1.响应式
 
 现在一个网站不是响应式都不好意思拿出手了。Ghostwill 针对移动设备做了优化，暂时是比较简单的处理，下一步将对菜单导航和交互做进一步优化和处理，详情请看 Github Commit log和该文章的更新日志 Update log 。
 
 ![](http://file.is26.com/wp-image/2014/04/ghost-mobile.png)
 
 
-###自定义Cover image
+### 自定义Cover image
 
 你要说我抄袭 [Medium](https://medium.com/)，嗯哼，你要说也没办法，自己过去看了不少国外网站，发现这种大 Banner 、大图片、大字体算是一大趋势。尤其是博客和资讯，大量留白，专注于中部核心内容。Ghostwill 支持用户自定义封面照片。
 
@@ -50,13 +50,13 @@ for more info.Please contact [@foru17](http://twitter.com/foru17)
 PS:封面照片有视觉滚差效果。
 
 
-###自选宽屏图片、视频
+### 自选宽屏图片、视频
 
 ![](http://qiniu.is26.com/demo-show-wide.png)
 
 通过给图片 `img` 标签设置 alt 值 `wrap`，给视频和其他 `iframe` 或者 `frame` 添加`class="wrap"`，可以让该[图片、视频、frame]自适应屏幕宽屏显示。对于有些需要重点突出的大图，可以根据需求自定义设置。
 
-###文章内 url 体验优化
+### 文章内 url 体验优化
 
 ![iconfont](http://qiniu.is26.com/iconfont-opt.jpg)
 
@@ -65,7 +65,7 @@ PS:封面照片有视觉滚差效果。
 这是我自己写的一个插件，过段时间单独提取出来给其他平台的用户也用用。
 
 
-###代码优化
+### 代码优化
 
 ```language-css
 .hello{
@@ -77,33 +77,33 @@ PS:封面照片有视觉滚差效果。
 
 采用 [Prismjs](http://prismjs.com/)，对不同的代码高亮和添加颜色主题。
 
-###社交icon
+### 社交icon
 
 ![](http://luolei.u.qiniudn.com/social-icons.jpg)
 
 博客顶部可以设置自己的社交网站链接，均使用 iconfont ，果断时间分享一下如何自己配置 iconfont 的教程。
 
-###其他
+### 其他
 
 这是一个 HTML5 的主题，从一开始我就就没想支持IE8以下的用户，IE的用户就洗洗睡吧。（主要是根据自己博客的统计数据来的，现在我博客每天大概700-800的UV，超过一半的访客用的是 Chrome 和移动端 webkit 浏览器我会随便说么，好歹也是高端访客嘛）。
 
-####Sass
+#### Sass
 
 开发的时候使用 CSS预处理[Sass](http://sass-lang.com/)。
 
-####Grunt
+#### Grunt
 
 必须 Grunt 自动化啊，另外放上自己的另外一篇文章[《让前端工作更快、更智能:利用StaticPage自动化工作流》](http://luolei.org/front-end-dev-with-grunt-staticpage-workflow/)。
 
-####前端优化
+#### 前端优化
 
 css 压缩,js 压缩，采用[又拍云](http://www.upyun.com/?md=luolei)CDN全站加速。
 
-####键盘控制
+#### 键盘控制
 
 这个是我随便加的功能，按键盘`J`屏幕下滚，`K`上翻，嗯哼，是 VIM 的操作习惯。
 
-###TO-DO-Task 待解决
+### TO-DO-Task 待解决
 
 2014.4月30日更新:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
